### PR TITLE
fix: modify get /message response from property

### DIFF
--- a/api-tests/message-api.spec.js
+++ b/api-tests/message-api.spec.js
@@ -727,6 +727,7 @@ describe('Message API tests.', () => {
             if (survey.title === survey_title) survey_two_exists = true;
             expect(message.to).to.have.length(1);
             expect(message.to[0]).to.have.keys(['recipient', 'type']);
+            expect(message.from).to.have.keys(['author', 'type']);
           }
 
           expect(survey_one_exists).to.be.true;

--- a/api-tests/message-api.spec.js
+++ b/api-tests/message-api.spec.js
@@ -184,9 +184,6 @@ describe('Message API tests.', () => {
         .where('subject', messagePostObject._object.subject)
         .where('body', messagePostObject._object.body)
         .where('composed_at', messagePostObject._object.composed_at)
-        .where('survey_response', {
-          survey_response: messagePostObject._object.survey_response,
-        })
         .where('video_link', messagePostObject._object.video_link);
 
       expect(message).have.lengthOf(1);

--- a/api-tests/message-post-class.js
+++ b/api-tests/message-post-class.js
@@ -16,7 +16,7 @@ class MessagePostObject extends GenericObject {
       body: 'Bodyyy',
       survey_id,
       composed_at: new Date().toISOString(),
-      survey_response: 'string',
+      survey_response: ['answer 1'],
       video_link: 'https://www.string.com',
     });
   }

--- a/docs/api/spec/treetracker-messaging-api.yaml
+++ b/docs/api/spec/treetracker-messaging-api.yaml
@@ -62,8 +62,13 @@ paths:
                           type: string
                           format: uuid
                         from:
-                          type: string
-                          minLength: 1
+                          type: object
+                            properties:
+                              author:
+                                type: string
+                              type:
+                                type: string
+                              
                         to:
                           type: array
                           items:

--- a/docs/api/spec/treetracker-messaging-api.yaml
+++ b/docs/api/spec/treetracker-messaging-api.yaml
@@ -63,7 +63,7 @@ paths:
                           format: uuid
                         from:
                           type: object
-                            properties:
+                          properties:
                               author:
                                 type: string
                               type:
@@ -169,6 +169,9 @@ paths:
                   subject: string
                   body: string
               properties:
+                id:
+                  type: string
+                  format: uuid
                 parent_message_id:
                   type: string
                   format: uuid
@@ -190,7 +193,8 @@ paths:
                   type: string
                   format: uuid
                 survey_response:
-                  type: string
+                  type: array
+                  items: string
                 video_link:
                   type: string
               required:

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -66,7 +66,7 @@ const Message = async ({
   return Object.freeze({
     id,
     parent_message_id,
-    from: author_handle,
+    from: { author: author_handle, type: 'user' },
     to,
     subject,
     body,

--- a/server/models/Message.js
+++ b/server/models/Message.js
@@ -32,7 +32,7 @@ const Message = async ({
       title,
       response: !!answer,
       questions,
-      answers: answer ? [answer] : null,
+      answers: answer?.length > 0 ? answer : null,
     };
   }
 
@@ -77,17 +77,18 @@ const Message = async ({
 };
 
 const MessageObject = ({
+  id = uuid(),
   subject,
   body,
   composed_at = new Date().toISOString(),
   survey_id = null,
-  survey_response = null,
+  survey_response,
   video_link = null,
   author_id,
   active = true,
 }) =>
   Object.freeze({
-    id: uuid(),
+    id,
     created_at: new Date().toISOString(),
     subject,
     body,


### PR DESCRIPTION
- changed the from property of the get /message response from a string to be an object with type and user properties
- updated the survey_response validation schema on /post from string to an array of strings
- included the option of receiving an id in order to account for possible duplicates for data coming through the bulk-pack
- updates the spec