### PR TITLE
Add necessary environment variables  & pass along error messages

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -2,3 +2,6 @@ DATABASE_URL=postgresql://s_{SCHEMA}:{PASSWORD}@db-postgresql-sfo2-nextgen-do-us
 DATABASE_SCHEMA={SCHEMA}
 DATABASE_URL_SEEDER=postgresql://m_{SCHEMA}:{SEEDER_PASSWORD}@db-postgresql-sfo2-nextgen-do-user-1067699-0.db.ondigitalocean.com:25060/treetracker?ssl=no-verify
 NODE_LOG_LEVEL=debug
+TREETRACKER_STAKEHOLDER_API_URL=http://localhost:3005
+TREETRACKER_REGION_API_URL=http://localhost:3004
+TREETRACKER_GROWER_ACCOUNT_QUERY_API_URL=http://localhost:3003

--- a/server/utils/utils.js
+++ b/server/utils/utils.js
@@ -39,10 +39,12 @@ exports.errorHandler = (err, req, res, _next) => {
       code: err.code,
       message: err.message,
     });
-  } else if (err instanceof ValidationError) {
+  } else if (err instanceof ValidationError || err.response.status === 422) {
     res.status(422).send({
       code: 422,
-      message: err.details.map((m) => m.message).join(';'),
+      message: err.details
+        ? err.details.map((m) => m.message).join(';')
+        : err.response.data.message,
     });
   } else {
     res.status(500).send({


### PR DESCRIPTION
422 errors are generated with different formats. One has more details and the other just has a string message.
Pass both formats to the client.